### PR TITLE
支援 YouTube 影片

### DIFF
--- a/apod/cli.py
+++ b/apod/cli.py
@@ -106,9 +106,13 @@ def _convert_blogger_post_to_markdown(post):
 
     try:
         image = soup.find(href=re.compile("https://1.bp.blogspot.com/")).get("href")
+        video = None
     except Exception:
         image = None
-        video = soup.find(src=re.compile("https://youtube.com/embed")).get("src")
+        video_embed = soup.find(src=re.compile("https://youtube.com/embed")).get("src")
+        video_id = video_embed.split("/")[-1]
+        video = f"https://www.youtube.com/watch?v={video_id}"
+    media = f"video: {video}" if video else f"image: {image}"
 
     source = soup.find(href=re.compile("https://apod.nasa.gov/apod/ap"))
     source_title = source.text.strip()
@@ -157,7 +161,7 @@ title: {title}
 description:
 date: {date.format("YYYY-MM-DD")}
 tags: {tags}
-image: {image or video}
+{media}
 summary: {summary}
 aliases:
   - /{date.format("YYYY/MM/YYYYMMDD")}.html

--- a/apod/cli.py
+++ b/apod/cli.py
@@ -112,7 +112,6 @@ def _convert_blogger_post_to_markdown(post):
         video_embed = soup.find(src=re.compile("https://youtube.com/embed")).get("src")
         video_id = video_embed.split("/")[-1]
         video = f"https://www.youtube.com/watch?v={video_id}"
-    media = f"video: {video}" if video else f"image: {image}"
 
     source = soup.find(href=re.compile("https://apod.nasa.gov/apod/ap"))
     source_title = source.text.strip()
@@ -161,7 +160,7 @@ title: {title}
 description:
 date: {date.format("YYYY-MM-DD")}
 tags: {tags}
-{media}
+hero: {video or image}
 summary: {summary}
 aliases:
   - /{date.format("YYYY/MM/YYYYMMDD")}.html

--- a/content/posts/2020/12/20201228.md
+++ b/content/posts/2020/12/20201228.md
@@ -3,7 +3,7 @@ title: M16：鴟鴞星雲的內部
 description:
 date: 2020-12-28
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-o5PxN3zIQzc/X-ol2LdbRLI/AAAAAAAAAAM/yPbPAg6RW6QOss1H7OUKz9A4Vo5-_87BwCLcBGAsYHQ/s2048/EagleNebula_Paladini_2854.jpeg
+hero: https://1.bp.blogspot.com/-o5PxN3zIQzc/X-ol2LdbRLI/AAAAAAAAAAM/yPbPAg6RW6QOss1H7OUKz9A4Vo5-_87BwCLcBGAsYHQ/s2048/EagleNebula_Paladini_2854.jpeg
 summary: 遠遠仔看，這規个形體看起來就親像是一隻鴟鴞。
 aliases:
   - /2020/12/20201228.html

--- a/content/posts/2020/12/20201229.md
+++ b/content/posts/2020/12/20201229.md
@@ -3,7 +3,7 @@ title: 地球佇日全食的模樣
 description:
 date: 2020-12-29
 tags: ['逐工一幅天文圖']
-video: https://www.youtube.com/watch?v=4Kkd2k0pDsI
+hero: https://www.youtube.com/watch?v=4Kkd2k0pDsI
 summary: 發生日全食 ê 時陣，地球看起來是按怎？看著日全食 ê 時陣，彼搭就會變暗。
 aliases:
   - /2020/12/20201229.html

--- a/content/posts/2020/12/20201229.md
+++ b/content/posts/2020/12/20201229.md
@@ -3,7 +3,7 @@ title: 地球佇日全食的模樣
 description:
 date: 2020-12-29
 tags: ['逐工一幅天文圖']
-image: https://youtube.com/embed/4Kkd2k0pDsI
+video: https://www.youtube.com/watch?v=4Kkd2k0pDsI
 summary: 發生日全食 ê 時陣，地球看起來是按怎？看著日全食 ê 時陣，彼搭就會變暗。
 aliases:
   - /2020/12/20201229.html

--- a/content/posts/2020/12/20201230.md
+++ b/content/posts/2020/12/20201230.md
@@ -3,7 +3,7 @@ title: 木星佮土星大相拄
 description:
 date: 2020-12-30
 tags: ['逐工一幅天文圖']
-video: https://www.youtube.com/watch?v=aokGqxVdpz0
+hero: https://www.youtube.com/watch?v=aokGqxVdpz0
 summary: 是滴！毋知你敢捌看過木星佮土星相拄 ê 影片無？這个 kā 幾若張相片組合做縮時攝影 ê 影片是佇泰國翕 ê。
 aliases:
   - /2020/12/20201230.html

--- a/content/posts/2020/12/20201230.md
+++ b/content/posts/2020/12/20201230.md
@@ -3,7 +3,7 @@ title: 木星佮土星大相拄
 description:
 date: 2020-12-30
 tags: ['逐工一幅天文圖']
-image: https://youtube.com/embed/aokGqxVdpz0
+video: https://www.youtube.com/watch?v=aokGqxVdpz0
 summary: 是滴！毋知你敢捌看過木星佮土星相拄 ê 影片無？這个 kā 幾若張相片組合做縮時攝影 ê 影片是佇泰國翕 ê。
 aliases:
   - /2020/12/20201230.html

--- a/content/posts/2020/12/20201231.md
+++ b/content/posts/2020/12/20201231.md
@@ -3,7 +3,7 @@ title: 轉返船 ê 痕跡
 description:
 date: 2020-12-31
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-Rixc-my-KoU/X-3k_GfGZPI/AAAAAAAAAAc/EA5yDYTSTpU8ERRRPD4UVvrghlvFmrIJgCLcBGAsYHQ/s1000/fireball_trail2.jpeg
+hero: https://1.bp.blogspot.com/-Rixc-my-KoU/X-3k_GfGZPI/AAAAAAAAAAc/EA5yDYTSTpU8ERRRPD4UVvrghlvFmrIJgCLcBGAsYHQ/s1000/fireball_trail2.jpeg
 summary: 這張相片是佇中國甘肅張掖佮內蒙古邊界翕 ê，看會著咱熟似 ê北半球天星 ê 寒天夜空。
 aliases:
   - /2020/12/20201231.html

--- a/content/posts/2021/01/20210101.md
+++ b/content/posts/2021/01/20210101.md
@@ -3,7 +3,7 @@ title: 星系佮南天極
 description:
 date: 2021-01-01
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-a8VMbcdaICo/X_AacnLIPNI/AAAAAAAAAAo/6C_dPgXizA0OUgVcCgyPHSYCtQNNrDczwCLcBGAsYHQ/s1500/2020_12_16_Kujal_Jizni_Pol_1500px-3.jpeg
+hero: https://1.bp.blogspot.com/-a8VMbcdaICo/X_AacnLIPNI/AAAAAAAAAAo/6C_dPgXizA0OUgVcCgyPHSYCtQNNrDczwCLcBGAsYHQ/s1500/2020_12_16_Kujal_Jizni_Pol_1500px-3.jpeg
 summary: 佇濟濟星跡影像內底，南天極佇南半球真簡單著會當揣著。
 aliases:
   - /2021/01/20210101.html

--- a/content/posts/2021/01/20210102.md
+++ b/content/posts/2021/01/20210102.md
@@ -3,7 +3,7 @@ title: 21 世紀溼版翕相法翕 ê 月球
 description:
 date: 2021-01-02
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-Qd1vZLjFy64/X_DEbNYmM9I/AAAAAAAAAA0/yKUmhP2cXrcUqLEyiVvtDvMVzCs7mVYBgCLcBGAsYHQ/s1024/WetCollodionLunar112820SMO_1024.jpeg
+hero: https://1.bp.blogspot.com/-Qd1vZLjFy64/X_DEbNYmM9I/AAAAAAAAAA0/yKUmhP2cXrcUqLEyiVvtDvMVzCs7mVYBgCLcBGAsYHQ/s1024/WetCollodionLunar112820SMO_1024.jpeg
 summary: 佇 19 世紀中，一款上早用來翕月球表面 ê 技術叫做溼版火棉膠處理法。
 aliases:
   - /2021/01/20210102.html

--- a/content/posts/2021/01/20210103.md
+++ b/content/posts/2021/01/20210103.md
@@ -3,7 +3,7 @@ title: 佇冰島頂懸 ê 鳳凰極光
 description:
 date: 2021-01-03
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-2Bd7K1JQ4KA/X_GF4tOYWPI/AAAAAAAAABA/0uFFh05pOxI9ptfAOIuegDRKXPpmWLh3wCLcBGAsYHQ/s960/PhoenixAurora_Helgason_960_annotated.jpeg
+hero: https://1.bp.blogspot.com/-2Bd7K1JQ4KA/X_GF4tOYWPI/AAAAAAAAABA/0uFFh05pOxI9ptfAOIuegDRKXPpmWLh3wCLcBGAsYHQ/s960/PhoenixAurora_Helgason_960_annotated.jpeg
 summary: 看極光 ê 人攏轉去矣！佇冰島九月一个安靜 ê 暗暝，半暝三點半，大部份 ê 極光攏已經消失矣。
 aliases:
   - /2021/01/20210103.html

--- a/content/posts/2021/01/20210104.md
+++ b/content/posts/2021/01/20210104.md
@@ -3,7 +3,7 @@ title: 一秒鐘爍十萬改 ê 紅色精靈
 description:
 date: 2021-01-04
 tags: ['逐工一幅天文圖']
-video: https://www.youtube.com/watch?v=zS_XgF9i8tc
+hero: https://www.youtube.com/watch?v=zS_XgF9i8tc
 summary: 紅色精靈。
 aliases:
   - /2021/01/20210104.html

--- a/content/posts/2021/01/20210104.md
+++ b/content/posts/2021/01/20210104.md
@@ -3,7 +3,7 @@ title: 一秒鐘爍十萬改 ê 紅色精靈
 description:
 date: 2021-01-04
 tags: ['逐工一幅天文圖']
-image: https://youtube.com/embed/zS_XgF9i8tc
+video: https://www.youtube.com/watch?v=zS_XgF9i8tc
 summary: 紅色精靈。
 aliases:
   - /2021/01/20210104.html

--- a/content/posts/2021/01/20210105.md
+++ b/content/posts/2021/01/20210105.md
@@ -3,7 +3,7 @@ title: 小麥哲倫星雲
 description:
 date: 2021-01-05
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-nRn5fgcMIrE/X_Q8MdJLREI/AAAAAAAAABg/ibgrgaiz9JI2kJykvsXJSva-Kxs8jwMqwCLcBGAsYHQ/s960/SMC_Mtanous_960.jpeg
+hero: https://1.bp.blogspot.com/-nRn5fgcMIrE/X_Q8MdJLREI/AAAAAAAAABg/ibgrgaiz9JI2kJykvsXJSva-Kxs8jwMqwCLcBGAsYHQ/s960/SMC_Mtanous_960.jpeg
 summary: 啥物是小麥哲倫星雲？伊其實是一个星系。
 aliases:
   - /2021/01/20210105.html

--- a/content/posts/2021/01/20210106.md
+++ b/content/posts/2021/01/20210106.md
@@ -3,7 +3,7 @@ title: 佇火星 ê 沙條崙
 description:
 date: 2021-01-06
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-mdV2Bya90e8/X_V3nOUpchI/AAAAAAAAABs/u-Q4CvqnxAYwzcxeXIahNwX1Ej6aYtMEgCLcBGAsYHQ/s1080/StripedDunes_HiRISE_1080.jpeg
+hero: https://1.bp.blogspot.com/-mdV2Bya90e8/X_V3nOUpchI/AAAAAAAAABs/u-Q4CvqnxAYwzcxeXIahNwX1Ej6aYtMEgCLcBGAsYHQ/s1080/StripedDunes_HiRISE_1080.jpeg
 summary: 火星面頂 ê 沙崙是按怎變做一條一條 ê？無人知影。
 aliases:
   - /2021/01/20210106.html

--- a/content/posts/2021/01/20210107.md
+++ b/content/posts/2021/01/20210107.md
@@ -3,7 +3,7 @@ title: 2020 年 ê 日全食
 description:
 date: 2021-01-07
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-b4D0r-3t5QI/X_a7MAHELyI/AAAAAAAAAB4/NtSTg7nCKoYZH8PTRlBJk-O5ub375QLWwCLcBGAsYHQ/s1100/Tse_2020_400mm_dmwa-rot.jpeg
+hero: https://1.bp.blogspot.com/-b4D0r-3t5QI/X_a7MAHELyI/AAAAAAAAAB4/NtSTg7nCKoYZH8PTRlBJk-O5ub375QLWwCLcBGAsYHQ/s1100/Tse_2020_400mm_dmwa-rot.jpeg
 summary: 今年唯一 ê 一改日全食，是佇 2020 年 12 月 14 上尾一改 ê 新月，úi 太陽面頭前行過。
 aliases:
   - /2021/01/20210107.html

--- a/content/posts/2021/01/20210108.md
+++ b/content/posts/2021/01/20210108.md
@@ -3,7 +3,7 @@ title: NGC 1365：壯麗 ê 宇宙島
 description:
 date: 2021-01-08
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-Jby1h_aJCfk/X_gZY9iDB7I/AAAAAAAAACE/J4L5iIt4Zgo1Q_sE7MpgskgtJrEbTxE0ACLcBGAsYHQ/s1024/NGC-1365-RGB-19-DEC-2020_Leo_Mike_1024.jpeg
+hero: https://1.bp.blogspot.com/-Jby1h_aJCfk/X_gZY9iDB7I/AAAAAAAAACE/J4L5iIt4Zgo1Q_sE7MpgskgtJrEbTxE0ACLcBGAsYHQ/s1024/NGC-1365-RGB-19-DEC-2020_Leo_Mike_1024.jpeg
 summary: NGC 1365 這个棍螺仔星系差不多有 20 萬光年闊，是一个壯麗 ê宇宙島。
 aliases:
   - /2021/01/20210108.html

--- a/content/posts/2021/01/20210109.md
+++ b/content/posts/2021/01/20210109.md
@@ -3,7 +3,7 @@ title: 泰坦：Kā 土星閘牢 ê 衛星
 description:
 date: 2021-01-09
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-aMIqepgnLME/X_mfVukB_PI/AAAAAAAAACQ/VuE8ye9VudYLUko1GO5acOHtBI6inu90QCLcBGAsYHQ/s1024/PIA19642Titan1024.jpeg
+hero: https://1.bp.blogspot.com/-aMIqepgnLME/X_mfVukB_PI/AAAAAAAAACQ/VuE8ye9VudYLUko1GO5acOHtBI6inu90QCLcBGAsYHQ/s1024/PIA19642Titan1024.jpeg
 summary: To̍h 親像地球仝款，土星上大粒 ê 衛星泰坦嘛去予土星鎖牢，tùi 土星同步自轉矣。
 aliases:
   - /2021/01/20210109.html

--- a/content/posts/2021/01/20210110.md
+++ b/content/posts/2021/01/20210110.md
@@ -3,7 +3,7 @@ title: R136 星團大出
 description:
 date: 2021-01-10
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-HksblR0L7CM/X_qlznEWvkI/AAAAAAAAACc/A4kArdWBLskBYFAH9SW-9FUNY0aTlDR3wCLcBGAsYHQ/s960/30dor_hubble_960.jpeg
+hero: https://1.bp.blogspot.com/-HksblR0L7CM/X_qlznEWvkI/AAAAAAAAACc/A4kArdWBLskBYFAH9SW-9FUNY0aTlDR3wCLcBGAsYHQ/s960/30dor_hubble_960.jpeg
 summary: 佇影像中央 ê 恆星形成區附近，有一个非常大 ê 星團，內底有一寡上大質量又閣上高溫 ê 恆星。
 aliases:
   - /2021/01/20210110.html

--- a/content/posts/2021/01/20210111.md
+++ b/content/posts/2021/01/20210111.md
@@ -3,7 +3,7 @@ title: 2021 年規年 ê 月相
 description:
 date: 2021-01-11
 tags: ['逐工一幅天文圖']
-video: https://www.youtube.com/watch?v=8XV2-pmiyAg
+hero: https://www.youtube.com/watch?v=8XV2-pmiyAg
 summary: 月球佇你今年生日彼工會生做啥物款？這實在是真歹臆逐暗攏無仝（譯者佇遮那翻那想：台灣人若是有咧過舊曆生日，to̍h 一定會知影矣啦！攏免臆！）。
 aliases:
   - /2021/01/20210111.html

--- a/content/posts/2021/01/20210111.md
+++ b/content/posts/2021/01/20210111.md
@@ -3,7 +3,7 @@ title: 2021 年規年 ê 月相
 description:
 date: 2021-01-11
 tags: ['逐工一幅天文圖']
-image: https://youtube.com/embed/8XV2-pmiyAg
+video: https://www.youtube.com/watch?v=8XV2-pmiyAg
 summary: 月球佇你今年生日彼工會生做啥物款？這實在是真歹臆逐暗攏無仝（譯者佇遮那翻那想：台灣人若是有咧過舊曆生日，to̍h 一定會知影矣啦！攏免臆！）。
 aliases:
   - /2021/01/20210111.html

--- a/content/posts/2021/01/20210112.md
+++ b/content/posts/2021/01/20210112.md
@@ -3,7 +3,7 @@ title: 巴西古早時代 ê 星座
 description:
 date: 2021-01-12
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-B0EOS5I9VXg/X_1mQdrRWNI/AAAAAAAAACo/oieT4mFgjEEC6do-SbYpKxkatF_AuBnmACLcBGAsYHQ/s960/OldMan_Guerra_960_lines.jpeg
+hero: https://1.bp.blogspot.com/-B0EOS5I9VXg/X_1mQdrRWNI/AAAAAAAAACo/oieT4mFgjEEC6do-SbYpKxkatF_AuBnmACLcBGAsYHQ/s960/OldMan_Guerra_960_lines.jpeg
 summary: 咱 ê 夜空有真濟故事。
 aliases:
   - /2021/01/20210112.html

--- a/content/posts/2021/01/20210113.md
+++ b/content/posts/2021/01/20210113.md
@@ -3,7 +3,7 @@ title: 迒過北極天頂 ê 彎弓橋
 description:
 date: 2021-01-13
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-1ukn7sboZyE/X_6-OCumA2I/AAAAAAAAAC0/Xjahik__9QcU77ShMZuxbKsc6RddX9LkwCLcBGAsYHQ/s1080/ArcticSky_Cobianchi_1080_annotated.jpeg
+hero: https://1.bp.blogspot.com/-1ukn7sboZyE/X_6-OCumA2I/AAAAAAAAAC0/Xjahik__9QcU77ShMZuxbKsc6RddX9LkwCLcBGAsYHQ/s1080/ArcticSky_Cobianchi_1080_annotated.jpeg
 summary: 天頂彼兩 ê 大大 ê 彎弓橋是啥物？佇倒手爿彼个你可能知影，是咱銀河ê 中央盤。
 aliases:
   - /2021/01/20210113.html

--- a/content/posts/2021/01/20210114.md
+++ b/content/posts/2021/01/20210114.md
@@ -3,7 +3,7 @@ title: 天頂厚
 description:
 date: 2021-01-14
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-h9ADFdxeKZk/X__choe2qlI/AAAAAAAAADA/LSwnvOqOdfIluPsNivSdw-yzQJ5W02QwACLcBGAsYHQ/s2048/aurora_iss052e007857.jpeg
+hero: https://1.bp.blogspot.com/-h9ADFdxeKZk/X__choe2qlI/AAAAAAAAADA/LSwnvOqOdfIluPsNivSdw-yzQJ5W02QwACLcBGAsYHQ/s2048/aurora_iss052e007857.jpeg
 summary: 佇 2017 年 6 月 25 úi 國際太空站面頂翕 ê 這張地球表面厚 tut-tut ê 青色極光，to̍h 親像佇墨西哥潤餅面頂抹一重青色 ê 莎莎醬仝款。
 aliases:
   - /2021/01/20210114.html

--- a/content/posts/2021/01/20210115.md
+++ b/content/posts/2021/01/20210115.md
@@ -3,7 +3,7 @@ title: 冥王星 ê 地景
 description:
 date: 2021-01-15
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-0NRMNTPdpyo/YAEt3amFPnI/AAAAAAAAADM/vd6jqldcJ4EFN40RSogCKhD9Zgtd5AWHgCLcBGAsYHQ/s1024/Pluto-Mountains-Plains9-17-15_1024.jpeg
+hero: https://1.bp.blogspot.com/-0NRMNTPdpyo/YAEt3amFPnI/AAAAAAAAADM/vd6jqldcJ4EFN40RSogCKhD9Zgtd5AWHgCLcBGAsYHQ/s1024/Pluto-Mountains-Plains9-17-15_1024.jpeg
 summary: 踮這个足細、足遠 ê 世界，這个有光有影、有雄偉 ê 山脈佮冰原 ê 地景，to̍h 一直湠到地平線上尾彼爿。
 aliases:
   - /2021/01/20210115.html

--- a/content/posts/2021/01/20210116.md
+++ b/content/posts/2021/01/20210116.md
@@ -3,7 +3,7 @@ title: NGC 2174 ê 雲山
 description:
 date: 2021-01-16
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-HTD8r_nWu6A/YALw75hzQ6I/AAAAAAAAADs/e5tEH3aioeYoIJ_CvpGX7i0UoikQJAnxgCLcBGAsYHQ/s1024/hs-2014-18_n2174rotate1024.jpeg
+hero: https://1.bp.blogspot.com/-HTD8r_nWu6A/YALw75hzQ6I/AAAAAAAAADs/e5tEH3aioeYoIJ_CvpGX7i0UoikQJAnxgCLcBGAsYHQ/s1024/hs-2014-18_n2174rotate1024.jpeg
 summary: 這張奇幻 ê 天景ê 邊仔附近翕 ê。
 aliases:
   - /2021/01/20210116.html

--- a/content/posts/2021/01/20210117.md
+++ b/content/posts/2021/01/20210117.md
@@ -3,7 +3,7 @@ title: 真特殊 ê 半人馬座 A ê 噴流
 description:
 date: 2021-01-17
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-XpeiykWT2h4/YARETiqUuzI/AAAAAAAAAD4/G9xjemWMIZkWFFTYm342IiUIBDLi9WanQCLcBGAsYHQ/s960/CenAjets_EsoNasa_960.jpeg
+hero: https://1.bp.blogspot.com/-XpeiykWT2h4/YARETiqUuzI/AAAAAAAAAD4/G9xjemWMIZkWFFTYm342IiUIBDLi9WanQCLcBGAsYHQ/s960/CenAjets_EsoNasa_960.jpeg
 summary: 這个 ùi半人馬座 A噴出來 ê 噴流有百外萬光年長。
 aliases:
   - /2021/01/20210117.html

--- a/content/posts/2021/01/20210118.md
+++ b/content/posts/2021/01/20210118.md
@@ -3,7 +3,7 @@ title: 腦髓星雲 ê 超新星殘骸
 description:
 date: 2021-01-18
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/--Vl5GZfTBcA/YAUcbW3eEpI/AAAAAAAAAEI/NGNC5dh34GYII4NI00wdrW70v5b78YyOgCLcBGAsYHQ/s960/Medulla_Croman_960.jpeg
+hero: https://1.bp.blogspot.com/--Vl5GZfTBcA/YAUcbW3eEpI/AAAAAAAAAEI/NGNC5dh34GYII4NI00wdrW70v5b78YyOgCLcBGAsYHQ/s960/Medulla_Croman_960.jpeg
 summary: 是啥物驅動這个特殊 ê 星雲？CTB-1 是一萬年前佇仙后座方向 ê 一粒大質量恆星爆炸ê時陣留落來 ê 脹大 ê 氣體殼。
 aliases:
   - /2021/01/20210118.html

--- a/content/posts/2021/01/20210119.md
+++ b/content/posts/2021/01/20210119.md
@@ -3,7 +3,7 @@ title: 月華 kah 邊仔 ê 木星、土星
 description:
 date: 2021-01-19
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-C3STH-vS2qc/YAU4TFmn-qI/AAAAAAAAAEU/k0pD8pJbQv0DtsRPgCODEPUxF1dYy-VvwCLcBGAsYHQ/s1080/CoronaConjunction_Masi_1080_annotated.jpeg
+hero: https://1.bp.blogspot.com/-C3STH-vS2qc/YAU4TFmn-qI/AAAAAAAAAEU/k0pD8pJbQv0DtsRPgCODEPUxF1dYy-VvwCLcBGAsYHQ/s1080/CoronaConjunction_Masi_1080_annotated.jpeg
 summary: 是按怎有當時仔，去予雲閘著 ê 月娘看起來是七彩 ê？這款現像。
 aliases:
   - /2021/01/20210119.html

--- a/content/posts/2021/01/20210120.md
+++ b/content/posts/2021/01/20210120.md
@@ -3,7 +3,7 @@ title: 渦輪星系 ê 磁場
 description:
 date: 2021-01-20
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-jKJQywfxrDI/YAbtomGJyGI/AAAAAAAAAEw/C_4G8CXA7BYDAjKM7H029rFkCHzTvm5aACLcBGAsYHQ/s1200/M51Bfield_Sofia_960.jpeg
+hero: https://1.bp.blogspot.com/-jKJQywfxrDI/YAbtomGJyGI/AAAAAAAAAEw/C_4G8CXA7BYDAjKM7H029rFkCHzTvm5aACLcBGAsYHQ/s1200/M51Bfield_Sofia_960.jpeg
 summary: 磁場敢一定會佮星系 ê 捲螺仔手骨仝一个方向？這个用正面向咱 ê 渦輪星系，是佇盤仔形星系內底，一个看會著真清楚 ê 捲螺仔波形 ê 星系。
 aliases:
   - /2021/01/20210120.html

--- a/content/posts/2021/01/20210121.md
+++ b/content/posts/2021/01/20210121.md
@@ -3,7 +3,7 @@ title: M78 ê 闊幅相片
 description:
 date: 2021-01-21
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-wBrdBAc_U3U/YAjllwXxtwI/AAAAAAAAAFE/u-zXbhSTDfki0v3jvZRbl1ubzqfIFOWLgCLcBGAsYHQ/s1024/M78wideHiggins1024.jpeg
+hero: https://1.bp.blogspot.com/-wBrdBAc_U3U/YAjllwXxtwI/AAAAAAAAAFE/u-zXbhSTDfki0v3jvZRbl1ubzqfIFOWLgCLcBGAsYHQ/s1024/M78wideHiggins1024.jpeg
 summary: 佇肥 chut-chut ê臘戶座。
 aliases:
   - /2021/01/20210121.html

--- a/content/posts/2021/01/20210122.md
+++ b/content/posts/2021/01/20210122.md
@@ -3,7 +3,7 @@ title: 銀河環
 description:
 date: 2021-01-22
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-wBBHgFyXEMI/YApocw45OsI/AAAAAAAAAFc/7QI_IGGO5L8ZZOQb7GozGri9O81AMdj8gCLcBGAsYHQ/s1024/MilkyWayRingAlvinWu1024.jpeg
+hero: https://1.bp.blogspot.com/-wBBHgFyXEMI/YApocw45OsI/AAAAAAAAAFc/7QI_IGGO5L8ZZOQb7GozGri9O81AMdj8gCLcBGAsYHQ/s1024/MilkyWayRingAlvinWu1024.jpeg
 summary: 咱 ê 銀河盤面頂，有闊莽莽ê 宇宙塗粉、恆星、佮星雲。
 aliases:
   - /2021/01/20210122.html

--- a/content/posts/2021/01/20210123.md
+++ b/content/posts/2021/01/20210123.md
@@ -3,7 +3,7 @@ title: 仙后座 A ê 輪迴
 description:
 date: 2021-01-23
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-lbiCwuKrxE8/YAw16LXUv6I/AAAAAAAAAFo/q1J7UOh0xbc4JwAh1HQtZbS5v2AVTMWHwCLcBGAsYHQ/s1024/Chandrafirstlight_0_1024.jpeg
+hero: https://1.bp.blogspot.com/-lbiCwuKrxE8/YAw16LXUv6I/AAAAAAAAAFo/q1J7UOh0xbc4JwAh1HQtZbS5v2AVTMWHwCLcBGAsYHQ/s1024/Chandrafirstlight_0_1024.jpeg
 summary: 佇銀河內底 ê 大質量恆星，in ê 一生活甲有夠精彩 ê  啦！代先 ùi 宇宙雲海開始崩塌。
 aliases:
   - /2021/01/20210123.html

--- a/content/posts/2021/01/20210124.md
+++ b/content/posts/2021/01/20210124.md
@@ -3,7 +3,7 @@ title: 厝邊 ê 大質量捲螺仔星系 NGC 2841
 description:
 date: 2021-01-24
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-GON99Pdac-E/YAnPY9am-TI/AAAAAAAAAFQ/qOUYgj_WLIckCD9x_hgVxhi34MKaClj5ACLcBGAsYHQ/s960/ngc2841_hstColombari_960.jpeg
+hero: https://1.bp.blogspot.com/-GON99Pdac-E/YAnPY9am-TI/AAAAAAAAAFQ/qOUYgj_WLIckCD9x_hgVxhi34MKaClj5ACLcBGAsYHQ/s960/ngc2841_hstColombari_960.jpeg
 summary: NGC 2841是一个咱熟似 ê 大質量星系。
 aliases:
   - /2021/01/20210124.html

--- a/content/posts/2021/01/20210125.md
+++ b/content/posts/2021/01/20210125.md
@@ -3,7 +3,7 @@ title: 智利火山頭頂 ê 南十字
 description:
 date: 2021-01-25
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-pC3zqCYBS4U/YA3anyeCjsI/AAAAAAAAAGA/5BaMNJYFoQAQo1vxILOZQ9z8jvUmDIyAwCLcBGAsYHQ/s960/SouthernCross_Slovinsky_960_annotated.jpeg
+hero: https://1.bp.blogspot.com/-pC3zqCYBS4U/YA3anyeCjsI/AAAAAAAAAGA/5BaMNJYFoQAQo1vxILOZQ9z8jvUmDIyAwCLcBGAsYHQ/s960/SouthernCross_Slovinsky_960_annotated.jpeg
 summary: 你敢有看過南十字？伊是地球南半球 siāng 有名 ê 四粒星。
 aliases:
   - /2021/01/20210125.html

--- a/content/posts/2021/01/20210126.md
+++ b/content/posts/2021/01/20210126.md
@@ -3,7 +3,7 @@ title: NGC 1316 ê 中央：星系相碰了後
 description:
 date: 2021-01-26
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-wpHoO1wF-Ug/YA7VnXtQQ6I/AAAAAAAAAGM/bEkqUeohC4E4r4DWCmLuyoMe9RU2G-KkwCLcBGAsYHQ/s960/NGC1316Center_HubbleNobre_960.jpeg
+hero: https://1.bp.blogspot.com/-wpHoO1wF-Ug/YA7VnXtQQ6I/AAAAAAAAAGM/bEkqUeohC4E4r4DWCmLuyoMe9RU2G-KkwCLcBGAsYHQ/s960/NGC1316Center_HubbleNobre_960.jpeg
 summary: 這个看起來遮爾奇怪 ê 星系，是按怎產生 ê ？為著欲揣出像 NGC 1316 這款，內底 ê 恆星、氣體、塗粉 lóng 四界亂掖 ê 情形 sī 按怎發生 ê ？天文學者soah-lâi 變做偵探。
 aliases:
   - /2021/01/20210126.html

--- a/content/posts/2021/01/20210127.md
+++ b/content/posts/2021/01/20210127.md
@@ -3,7 +3,7 @@ title: NGC 5775 ê 坦徛磁場
 description:
 date: 2021-01-27
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-B-7Fr2Mkm_4/YA_UWrbuB6I/AAAAAAAAAGY/cbL84EPm-x0LQC4LmJNk_50LtiZvu0zMgCLcBGAsYHQ/s1080/NGC5775_NraoEnglish_1080.jpeg
+hero: https://1.bp.blogspot.com/-B-7Fr2Mkm_4/YA_UWrbuB6I/AAAAAAAAAGY/cbL84EPm-x0LQC4LmJNk_50LtiZvu0zMgCLcBGAsYHQ/s1080/NGC5775_NraoEnglish_1080.jpeg
 summary: 捲螺仔星系 ê 磁場會當湠外闊？天文學者 tī 過去幾若十年 kan-na 知影 ū 一寡仔捲螺仔星系。
 aliases:
   - /2021/01/20210127.html

--- a/content/posts/2021/01/20210128.md
+++ b/content/posts/2021/01/20210128.md
@@ -3,7 +3,7 @@ title: M66 ê 特寫
 description:
 date: 2021-01-28
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-ay17FWNQ6SM/YBFGIlv3VfI/AAAAAAAAAGk/KK-luc4649UlcQGyUmAe6N_MtRCLWP8yQCLcBGAsYHQ/s1024/M66_Hubble_LeoShatz_Crop1024.jpeg
+hero: https://1.bp.blogspot.com/-ay17FWNQ6SM/YBFGIlv3VfI/AAAAAAAAAGk/KK-luc4649UlcQGyUmAe6N_MtRCLWP8yQCLcBGAsYHQ/s1024/M66_Hubble_LeoShatz_Crop1024.jpeg
 summary: 大閣媠 ê捲螺仔星系 M66ê 所在。
 aliases:
   - /2021/01/20210128.html

--- a/content/posts/2021/01/20210129.md
+++ b/content/posts/2021/01/20210129.md
@@ -3,7 +3,7 @@ title: 北美洲 ê 夜景
 description:
 date: 2021-01-29
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-DNfelQ78658/YBPC6GZTISI/AAAAAAAAAG0/x_jvfHj1A6wHdM-gG9NxAm-Ec56ngI42wCPcBGAYYCw/s1024/North-America-Nebula-Deepscape_Liron-Gertsman1024.jpeg
+hero: https://1.bp.blogspot.com/-DNfelQ78658/YBPC6GZTISI/AAAAAAAAAG0/x_jvfHj1A6wHdM-gG9NxAm-Ec56ngI42wCPcBGAYYCw/s1024/North-America-Nebula-Deepscape_Liron-Gertsman1024.jpeg
 summary: 這張是 tī 1 月 21 翕 ê，差不多初七左右，月光 to̍h 照著前景這个雪山 kah 夜景。
 aliases:
   - /2021/01/20210129.html

--- a/content/posts/2021/01/20210130.md
+++ b/content/posts/2021/01/20210130.md
@@ -3,7 +3,7 @@ title: 一萬兩千公尺懸 ê 南天景色
 description:
 date: 2021-01-30
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-YpmnTv7zsNw/YBR_FiK6v3I/AAAAAAAAAHI/vti9Gw0PUwASy5CZmV_pqWLAR-gDR2-UwCLcBGAsYHQ/s1200/SouthernSkyRohner1200.jpeg
+hero: https://1.bp.blogspot.com/-YpmnTv7zsNw/YBR_FiK6v3I/AAAAAAAAAHI/vti9Gw0PUwASy5CZmV_pqWLAR-gDR2-UwCLcBGAsYHQ/s1200/SouthernSkyRohner1200.jpeg
 summary: 這張富麗 ê 夜空影像是南天 ê 天文景色，是 tī厚雲 ê 地球頂懸翕 ê。
 aliases:
   - /2021/01/20210130.html

--- a/content/posts/2021/01/20210131.md
+++ b/content/posts/2021/01/20210131.md
@@ -3,7 +3,7 @@ title: 遠方 ê 小行星
 description:
 date: 2021-01-31
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-NrIrkfZYYcE/YBRh-Csj0uI/AAAAAAAAAG8/dCwJjG5NzWQXMyFB4elUUMjVYDOkxQq5QCLcBGAsYHQ/s960/AsteroidStreak_hst_960.jpeg
+hero: https://1.bp.blogspot.com/-NrIrkfZYYcE/YBRh-Csj0uI/AAAAAAAAAG8/dCwJjG5NzWQXMyFB4elUUMjVYDOkxQq5QCLcBGAsYHQ/s960/AsteroidStreak_hst_960.jpeg
 summary: 逐工攏有 ùi 太空掔過來地球 ê 石頭。
 aliases:
   - /2021/01/20210131.html

--- a/content/posts/2021/02/20210201.md
+++ b/content/posts/2021/02/20210201.md
@@ -3,7 +3,7 @@ title: Tī 雪樹頭殼頂 ê 月暈
 description:
 date: 2021-02-01
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-QYVGmdf6nT8/YBbIDa8mJZI/AAAAAAAAAHU/mN8Wc0Za5cwcXexaA6J2Vgb0DpZ5rr6BwCLcBGAsYHQ/s960/LunarHalo_Strand_960.jpeg
+hero: https://1.bp.blogspot.com/-QYVGmdf6nT8/YBbIDa8mJZI/AAAAAAAAAHU/mN8Wc0Za5cwcXexaA6J2Vgb0DpZ5rr6BwCLcBGAsYHQ/s960/LunarHalo_Strand_960.jpeg
 summary: 你敢捌看過月娘罩著，才產生 ê 現象。
 aliases:
   - /2021/02/20210201.html

--- a/content/posts/2021/02/20210202.md
+++ b/content/posts/2021/02/20210202.md
@@ -3,7 +3,7 @@ title: 七彩 ê 四分儀座流星
 description:
 date: 2021-02-02
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-QCGcvsT7lBU/YBfc_0wjBHI/AAAAAAAAAHg/pn__N4OJUU83GThPfkObdb0IzaxZYwpQQCLcBGAsYHQ/s1080/MeteorStreak_Kuszaj_1080.jpeg
+hero: https://1.bp.blogspot.com/-QCGcvsT7lBU/YBfc_0wjBHI/AAAAAAAAAHg/pn__N4OJUU83GThPfkObdb0IzaxZYwpQQCLcBGAsYHQ/s1080/MeteorStreak_Kuszaj_1080.jpeg
 summary: 流星會使 sī 七彩 ê。
 aliases:
   - /2021/02/20210202.html

--- a/content/posts/2021/02/20210203.md
+++ b/content/posts/2021/02/20210203.md
@@ -3,7 +3,7 @@ title: Tī 月球揣著 ê：可能 sī 地球上老 ê 石頭
 description:
 date: 2021-02-03
 tags: ['逐工一幅天文圖']
-video: https://www.youtube.com/watch?v=V0UBZh6Hf-s
+hero: https://www.youtube.com/watch?v=V0UBZh6Hf-s
 summary: 地球上老 ê 石頭，敢是 tī 月球面頂揣著 ê？這真有可能！這个故事 to̍h 愛 ùi 月球任務阿波羅 14 號講起。
 aliases:
   - /2021/02/20210203.html

--- a/content/posts/2021/02/20210203.md
+++ b/content/posts/2021/02/20210203.md
@@ -3,7 +3,7 @@ title: Tī 月球揣著 ê：可能 sī 地球上老 ê 石頭
 description:
 date: 2021-02-03
 tags: ['逐工一幅天文圖']
-image: https://youtube.com/embed/V0UBZh6Hf-s
+video: https://www.youtube.com/watch?v=V0UBZh6Hf-s
 summary: 地球上老 ê 石頭，敢是 tī 月球面頂揣著 ê？這真有可能！這个故事 to̍h 愛 ùi 月球任務阿波羅 14 號講起。
 aliases:
   - /2021/02/20210203.html

--- a/content/posts/2021/02/20210204.md
+++ b/content/posts/2021/02/20210204.md
@@ -3,7 +3,7 @@ title: 阿波羅 14 號：Ùi Antares 看著 ê 景色
 description:
 date: 2021-02-04
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-grYOwbEsF04/YBtnl7nqyPI/AAAAAAAAAHs/OKhuyqyW-fEuGAm_4odyuPqJdTUtFTYIQCLcBGAsYHQ/s900/a14pan9335-43emj_900.jpg
+hero: https://1.bp.blogspot.com/-grYOwbEsF04/YBtnl7nqyPI/AAAAAAAAAHs/OKhuyqyW-fEuGAm_4odyuPqJdTUtFTYIQCLcBGAsYHQ/s900/a14pan9335-43emj_900.jpg
 summary: 五十年前ê 這禮拜五（2月初5），阿波羅 14 號 ê 登月小艇 Antares 登陸月球。
 aliases:
   - /2021/02/20210204.html

--- a/content/posts/2021/02/20210205.md
+++ b/content/posts/2021/02/20210205.md
@@ -3,7 +3,7 @@ title: 阿波羅 14 號欲轉來矣！
 description:
 date: 2021-02-05
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-EJLVP9_SWTs/YBzLoni_YOI/AAAAAAAAAH4/7VL6X15tKvY5h4x0W1EXxTOKeTXsxWUswCLcBGAsYHQ/s2000/AS14-71-9845v2wmktwtr4Jerry.jpg
+hero: https://1.bp.blogspot.com/-EJLVP9_SWTs/YBzLoni_YOI/AAAAAAAAAH4/7VL6X15tKvY5h4x0W1EXxTOKeTXsxWUswCLcBGAsYHQ/s2000/AS14-71-9845v2wmktwtr4Jerry.jpg
 summary: 五十年前。
 aliases:
   - /2021/02/20210205.html

--- a/content/posts/2021/02/20210206.md
+++ b/content/posts/2021/02/20210206.md
@@ -3,7 +3,7 @@ title: 北方寒天 ê 暗暝
 description:
 date: 2021-02-06
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-NTCdetHk0j0/YB4re1yrFFI/AAAAAAAAAIc/7sYuud97O0Md0US9qjfVOxfvDzyZM58vwCLcBGAsYHQ/s1024/Siemiony_las_31_01_2021_1024.jpg
+hero: https://1.bp.blogspot.com/-NTCdetHk0j0/YB4re1yrFFI/AAAAAAAAAIc/7sYuud97O0Md0US9qjfVOxfvDzyZM58vwCLcBGAsYHQ/s1024/Siemiony_las_31_01_2021_1024.jpg
 summary: Tī 這个恬靜 ê 森林 kah 夜空，白雪 to̍h 親像一領毯仔仝款崁 tī塗跤。
 aliases:
   - /2021/02/20210206.html

--- a/content/posts/2021/02/20210207.md
+++ b/content/posts/2021/02/20210207.md
@@ -3,7 +3,7 @@ title: 球形星團 M53 內底 ê 藍色浪星
 description:
 date: 2021-02-07
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-_Jmij_0ARGQ/YB04gyPxOTI/AAAAAAAAAIE/Juh8LFYg0FgX3Umtm7vGf9f0iMP8wQe4gCLcBGAsYHQ/s988/m53_hubble_960.jpg
+hero: https://1.bp.blogspot.com/-_Jmij_0ARGQ/YB04gyPxOTI/AAAAAAAAAIE/Juh8LFYg0FgX3Umtm7vGf9f0iMP8wQe4gCLcBGAsYHQ/s988/m53_hubble_960.jpg
 summary: 太陽若是這个星團 ê 一部份，咱 ê夜空to̍h 會 kah 珠寶盒仝款金光閃閃。
 aliases:
   - /2021/02/20210207.html

--- a/content/posts/2021/02/20210208.md
+++ b/content/posts/2021/02/20210208.md
@@ -3,7 +3,7 @@ title: WR32 kah 龍骨座內底 ê 星際雲
 description:
 date: 2021-02-08
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-vFUud_hpKrY/YB6PNe6vMSI/AAAAAAAAAIo/86THdsIYxkEy_lvtPGuWxRG4nlTUdk7aACLcBGAsYHQ/s960/WR23Friends_cappelletti_960.jpg
+hero: https://1.bp.blogspot.com/-vFUud_hpKrY/YB6PNe6vMSI/AAAAAAAAAIo/86THdsIYxkEy_lvtPGuWxRG4nlTUdk7aACLcBGAsYHQ/s960/WR23Friends_cappelletti_960.jpg
 summary: 恆星 to̍h 敢若藝術家仝款。
 aliases:
   - /2021/02/20210208.html

--- a/content/posts/2021/02/20210209.md
+++ b/content/posts/2021/02/20210209.md
@@ -3,7 +3,7 @@ title: 毛蟹星雲脈動星 ê 閃光
 description:
 date: 2021-02-09
 tags: ['逐工一幅天文圖']
-image: https://youtube.com/embed/4on-e614tag
+video: https://www.youtube.com/watch?v=4on-e614tag
 summary: 這款爆炸一般來講會當毀滅咱 ê 太陽，毋閣這个爆炸煞留落來矣。
 aliases:
   - /2021/02/20210209.html

--- a/content/posts/2021/02/20210209.md
+++ b/content/posts/2021/02/20210209.md
@@ -3,7 +3,7 @@ title: 毛蟹星雲脈動星 ê 閃光
 description:
 date: 2021-02-09
 tags: ['逐工一幅天文圖']
-video: https://www.youtube.com/watch?v=4on-e614tag
+hero: https://www.youtube.com/watch?v=4on-e614tag
 summary: 這款爆炸一般來講會當毀滅咱 ê 太陽，毋閣這个爆炸煞留落來矣。
 aliases:
   - /2021/02/20210209.html

--- a/content/posts/2021/02/20210210.md
+++ b/content/posts/2021/02/20210210.md
@@ -3,7 +3,7 @@ title: 發出雷射光來馴服天空
 description:
 date: 2021-02-10
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-r13d3Zfs7iw/YCLHBY43dFI/AAAAAAAAAJA/s5s22OCI6tgsIzapiXVkwTNoEgST3zuVgCLcBGAsYHQ/s1440/AoLasers_Munoz_960.jpg
+hero: https://1.bp.blogspot.com/-r13d3Zfs7iw/YCLHBY43dFI/AAAAAAAAAJA/s5s22OCI6tgsIzapiXVkwTNoEgST3zuVgCLcBGAsYHQ/s1440/AoLasers_Munoz_960.jpg
 summary: 天星是按怎會爁光？這 to̍h 愛怪大氣層啦！是有一寡 kah 空氣溫度小可無仝 ê 氣體包 leh 運動 ê 時陣，kā ùi 遠方天體行過來 ê 光路拗曲去矣！大氣亂流 tùi 天文學家來講是一个麻煩。
 aliases:
   - /2021/02/20210210.html

--- a/content/posts/2021/02/20210211.md
+++ b/content/posts/2021/02/20210211.md
@@ -3,7 +3,7 @@ title: 天鵝座 2010
 description:
 date: 2021-02-11
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-iQK7MqHRn6w/YCSVtzLqAdI/AAAAAAAAAJQ/1j1cS-OBKKknd6HHoXX6jl-tvfqFm2BQACLcBGAsYHQ/s1100/00Cygnus_Visual_colors1100.jpg
+hero: https://1.bp.blogspot.com/-iQK7MqHRn6w/YCSVtzLqAdI/AAAAAAAAAJQ/1j1cS-OBKKknd6HHoXX6jl-tvfqFm2BQACLcBGAsYHQ/s1100/00Cygnus_Visual_colors1100.jpg
 summary: 星際塗粉 kah 發光 ê 氣體畫出。
 aliases:
   - /2021/02/20210211.html

--- a/content/posts/2021/02/20210212.md
+++ b/content/posts/2021/02/20210212.md
@@ -3,7 +3,7 @@ title: 捲螺仔星系 NGC 1350
 description:
 date: 2021-02-12
 tags: ['逐工一幅天文圖']
-image: https://1.bp.blogspot.com/-MyoAaZBIIrQ/YCUthY7RtOI/AAAAAAAAAJc/EAF-eQO5e_o6mP0yvBM-iq2TadGv6LstACLcBGAsYHQ/s2048/NGC1350_crop.jpg
+hero: https://1.bp.blogspot.com/-MyoAaZBIIrQ/YCUthY7RtOI/AAAAAAAAAJc/EAF-eQO5e_o6mP0yvBM-iq2TadGv6LstACLcBGAsYHQ/s2048/NGC1350_crop.jpg
 summary: 這个華麗 ê 宇宙島 to̍h tī 南天星座，天爐座內底，離咱有 85 百萬光年遠。
 aliases:
   - /2021/02/20210212.html

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,13 +6,15 @@
       <h1 class="post_title">{{ .Title }}</h1>
       <div class="post_body">
         <div class="post_inner">
-        {{ if isset .Params "video" }}
-          <div class="video">
-            {{ $videoId := index (last 1 (split .Params.video "=")) 0 }}
-            <iframe src="https://youtube.com/embed/{{ $videoId }}"></iframe>
-          </div>
-        {{ else if isset .Params "image" }}
-          <img src="{{ .Params.image }}" alt="{{ . }}" class="post_thumbnail">
+        {{ if isset .Params "hero" }}
+          {{ if hasPrefix .Params.hero "https://www.youtube.com/" }}
+            <div class="video">
+              {{ $videoId := index (last 1 (split .Params.hero "=")) 0 }}
+              <iframe src="https://youtube.com/embed/{{ $videoId }}"></iframe>
+            </div>
+          {{ else }}
+            <img src="{{ .Params.hero }}" alt="{{ . }}" class="post_thumbnail">
+          {{ end }}
         {{ end }}
           {{ .Content }}
         </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,9 +6,13 @@
       <h1 class="post_title">{{ .Title }}</h1>
       <div class="post_body">
         <div class="post_inner">
-        {{ with .Params.image }}
-          {{- $image := absURL (printf "%s" .) }}
-          <img src="{{ $image }}" alt="{{ . }}" class="post_thumbnail">
+        {{ if isset .Params "video" }}
+          <div class="video">
+            {{ $videoId := index (last 1 (split .Params.video "=")) 0 }}
+            <iframe src="https://youtube.com/embed/{{ $videoId }}"></iframe>
+          </div>
+        {{ else if isset .Params "image" }}
+          <img src="{{ .Params.image }}" alt="{{ . }}" class="post_thumbnail">
         {{ end }}
           {{ .Content }}
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,11 +5,13 @@
   {{- $size := $paginator.PageSize }}
   {{- $scratch := newScratch }}
   {{- range $index, $value := $paginator.Pages }}
-    {{ if isset .Params "video" }}
-      {{ $videoId := index (last 1 (split .Params.video "=")) 0 }}
-      {{ $scratch.Set "image" (printf "https://img.youtube.com/vi/%s/hqdefault.jpg" $videoId) }}
-    {{ else if isset .Params "image" }}
-      {{ $scratch.Set "image" .Params.image }}
+    {{ if isset .Params "hero" }}
+      {{ if hasPrefix .Params.hero "https://www.youtube.com/" }}
+        {{ $videoId := index (last 1 (split .Params.hero "=")) 0 }}
+        {{ $scratch.Set "image" (printf "https://img.youtube.com/vi/%s/hqdefault.jpg" $videoId) }}
+      {{ else }}
+        {{ $scratch.Set "image" .Params.hero }}
+      {{ end }}
     {{ else }}
       {{ $scratch.Set "image" "thumbnail.svg" }}
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,7 +5,10 @@
   {{- $size := $paginator.PageSize }}
   {{- $scratch := newScratch }}
   {{- range $index, $value := $paginator.Pages }}
-    {{ if isset .Params "image" }}
+    {{ if isset .Params "video" }}
+      {{ $videoId := index (last 1 (split .Params.video "=")) 0 }}
+      {{ $scratch.Set "image" (printf "https://img.youtube.com/vi/%s/hqdefault.jpg" $videoId) }}
+    {{ else if isset .Params "image" }}
       {{ $scratch.Set "image" .Params.image }}
     {{ else }}
       {{ $scratch.Set "image" "thumbnail.svg" }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -27,6 +27,11 @@
 <meta property="og:description" content="{{ $summary }}">
 <meta property="og:url" content="{{ $pl }}">
 <meta property="og:image" content="{{ $image }}">
+{{ if isset .Params "hero" }}
+  {{ if hasPrefix .Params.hero "https://www.youtube.com/" }}
+    <meta property="og:video" content="{{ .Params.hero }}">
+  {{ end }}
+{{ end }}
 {{- if eq .Section "blog" -}}
   {{- $date := .Date.Format "2006-02-01" -}}
   <meta property="article:published_time" content="{{ htmlUnescape $date }}" />

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -10,8 +10,13 @@
 {{- $summary = truncate 160 "" $summary }}
 {{- $logo := absURL (printf "%s" $params.logo) }}
 {{ $image := "" }}
-{{- with .Params.image }}
-  {{- $image = absURL (printf "%s" .) }}
+{{ if isset .Params "hero" }}
+  {{ if hasPrefix .Params.hero "https://www.youtube.com/" }}
+    {{- $videoId := index (last 1 (split .Params.hero "=")) 0 }}
+    {{- $image = absURL (printf "https://img.youtube.com/vi/%s/hqdefault.jpg" $videoId) }}
+  {{ else }}
+    {{- $image = absURL (printf "%s" .Params.hero) }}
+  {{ end }}
 {{- else }}
   {{- $image = $logo }}
 {{- end }}


### PR DESCRIPTION
## 目標

- 本來 meta 只能填 image，現在改填 hero
- hero 支援圖片或 YouTube 影片
- 支援 `og:video`

## 細節

- image 預設拿 `https://img.youtube.com/vi/<video_id>/hqdefault.jpg`

現在很多重複的 code 在 `single.html`、`index.html`、`opengraph.html`，其實就是判斷 hero 是否為 YouTube video 和取得 YouTube thumbnail 的部分，有機會再研究怎麼整合。
