### PR TITLE
調整頁面樣式

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -64,7 +64,6 @@ code
 
 h1,h2,h3,h4,h5
   font-family: inherit
-  text-transform: capitalize
   font-weight: 400
   padding: 0.33rem 0
   margin: 1rem 0

--- a/assets/sass/_nav.sass
+++ b/assets/sass/_nav.sass
@@ -122,6 +122,3 @@
 
   &-open
     animation: showMenu 0.5s cubic-bezier(0.52, 0.16, 0.24, 1) forwards
-
-  &_item
-    text-transform: capitalize

--- a/assets/sass/_posts.sass
+++ b/assets/sass/_posts.sass
@@ -40,7 +40,7 @@
     img
       width: 100%
       max-width: 100%
-  &_inner
+  &_inner,&_nav
     a
       color: var(--theme)
       transition: all 0.3s
@@ -150,17 +150,17 @@
       z-index: 1
       border-radius: 1rem
 
+  &_prev
+    display: inline-grid
+    margin: 0 auto 0 0
+    width: 1fr
+    grid-template-columns: 1.33rem 1fr
+
   &_next
     display: inline-grid
-    margin: 0 auto
-    width: 10rem
+    margin: 0 0 0 auto
+    width: 1fr
     grid-template-columns: 1fr 1.33rem
-    &::after
-      content: ""
-      background-image: url($next-icon-path)
-      background-repeat: repeat no-repeat
-      background-size: 0.8rem
-      background-position: center right
 
 .pager
   display: grid

--- a/assets/sass/_posts.sass
+++ b/assets/sass/_posts.sass
@@ -93,7 +93,6 @@
     align-items: center
     border-radius: 0.3rem
     color: var(--dark)
-    text-transform: capitalize
     a
       &:hover
         color: var(--theme)
@@ -110,7 +109,6 @@
     background: var(--theme)
     color: var(--light)
     padding: 0.25rem 0.67rem !important
-    text-transform: uppercase
     display: inline-flex
     border-radius: 5px
 
@@ -134,7 +132,6 @@
     text-align: center
     color: var(--theme)
     // box-shadow: 0 1rem 3rem -1rem rgba(0,0,0,0.15)
-    text-transform: uppercase
     &, span
       position: relative
       z-index: 3

--- a/assets/sass/_variables.sass
+++ b/assets/sass/_variables.sass
@@ -26,7 +26,7 @@ html
     --bg: var(--bg-dark)
     --text: var(--light)
     --accent: var(--bubble)
-    --theme: rgb(48,209,88)//rgb(24,175,119)
+    --theme: rgb(88,166,255)
     *
       box-shadow: none !important
 

--- a/assets/sass/_variables.sass
+++ b/assets/sass/_variables.sass
@@ -1,6 +1,4 @@
 $font-path: "../fonts/"
-$prev-icon-path: "../images/icons/previous.svg"
-$next-icon-path: "../images/icons/double-arrow.svg"
 $never-icon-path: "../images/sitting.svg"
 
 // orange  [rgb(255,149,0), rgb( 255,159,10)]

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
 baseurl: "https://test.apod.tw/"
 title: "逐工一幅天文圖 APOD Taiwanese"
 theme: "newsroom"
-paginate: 15
+paginate: 31

--- a/data/menu.yml
+++ b/data/menu.yml
@@ -1,0 +1,4 @@
+- item: Archive
+  url: posts/
+- item: About
+  url: about/

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,10 +26,25 @@
         </div>
       </div>
     </div>
-    <a href="{{ $.Site.BaseURL }}" class="post_nav"><span class="post_next">The Latest
-      <svg class="icon icon_scale">
-        <use xlink:href="#double-arrow"></use>
-      </svg>
-    </span></a>
+    {{ if eq .Type "posts" }}
+      <div class = 'grid-2 post_nav'>
+        {{ with .Prev }}
+          <span class="post_prev">
+            <svg class="icon icon_scale">
+              <use xlink:href="#double-arrow-left"></use>
+            </svg>
+            <a href="{{ .Permalink }}">昨昏 ê 圖：{{ .Title }}</a>
+          </span>
+        {{ end }}
+        {{ with .Next }}
+          <span class="post_next">
+            <a href="{{ .Permalink }}">明仔載 ê 圖：{{ .Title }}</a>
+              <svg class="icon icon_scale">
+                <use xlink:href="#double-arrow-right"></use>
+              </svg>
+          </span>
+        {{ end }}
+      </div>
+    {{ end }}
   </div>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,7 +29,7 @@
       </div>
     </a>
   </article>
-  {{- if and (eq $index 0) (gt $size 1)  }}<div class = 'grid-2 article_showcase'>{{ end }}
+  {{- if and (eq $index 0) (gt $size 1)  }}<div class = 'grid-4 article_showcase'>{{ end }}
   {{- if and (eq $index (add $size -1)) (gt $size 1) }}</div>{{ end }}
   {{- end }}
 </div>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -4,7 +4,6 @@
       <a href="{{ absURL .url }}" class="nav_item">{{ .item }}</a>
     {{- end }}
     <div class="nav-close"></div>
-    {{- partial "mode" . }}
   </div>
 </div>
 {{- partial "header" . }}

--- a/layouts/partials/sprites.html
+++ b/layouts/partials/sprites.html
@@ -5,4 +5,10 @@
   <symbol viewBox="0 0 53 42" xmlns="http://www.w3.org/2000/svg" id="double-arrow">
     <path d="M.595 39.653a1.318 1.318 0 0 1 0-1.864L16.55 21.833a1.318 1.318 0 0 0 0-1.863L.595 4.014a1.318 1.318 0 0 1 0-1.863L2.125.62a1.318 1.318 0 0 1 1.864 0l19.35 19.349a1.318 1.318 0 0 1 0 1.863l-19.35 19.35a1.318 1.318 0 0 1-1.863 0zm29 0a1.318 1.318 0 0 1 0-1.864L45.55 21.833a1.318 1.318 0 0 0 0-1.863L29.595 4.014a1.318 1.318 0 0 1 0-1.863l1.53-1.53a1.318 1.318 0 0 1 1.864 0l19.35 19.349a1.318 1.318 0 0 1 0 1.863l-19.35 19.35a1.318 1.318 0 0 1-1.863 0z"></path>
   </symbol>
+  <symbol xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" id="double-arrow-left">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+  </symbol>
+  <symbol xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" id="double-arrow-right">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+  </symbol>
 </svg>


### PR DESCRIPTION
做了以下調整：

- Theme color 從奇怪的綠色改成 GitHub 的藍色（？
- Menu 加上 archive 和 about，拿掉 mode switch，只有 dark mode！
- 讓首頁可以超過兩欄，一頁有 31 篇文章
- 每篇文章底下自動生出前一天和後一天的文章連結
- 拿掉自動大寫的 css 設定

未來希望 Archive 頁可以 by year，待研究。