### PR TITLE
予 `--` 莫換逝

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,5 +19,8 @@ taxonomies:
 
 markup:
   goldmark:
+    extensions:
+      typographer:
+        disable: true
     renderer:
       unsafe: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,10 +4,21 @@
   {{ partial "head" . }}
   <body>
     {{ partial "nav" . }}
-    <main>
-      {{ block "main" . }}{{ end }}
-    </main>
-    {{ partial "footer" . }}
-    {{ partial "sprites" . }}
+    <main>{{ block "main" . }}{{ end }}</main>
+    {{ partial "footer" . }} {{ partial "sprites" . }}
+    <script>
+      function traverseAndReplace(node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          if (node.nodeValue.includes("--")) {
+            node.nodeValue = node.nodeValue.replace(/--/g, "-\u2060-");
+          }
+        } else {
+          for (let i = 0; i < node.childNodes.length; i++) {
+            traverseAndReplace(node.childNodes[i]);
+          }
+        }
+      }
+      traverseAndReplace(document.body);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
蔡先生佮阿錕平安：

這改个 pull request 佇 baseof.html 檔案加一段 javascript 程式
這个程式會掠出所有的羅馬字輕聲符號 `--` ，加中央加一个 `U+2060` [Word joiner](https://en.wikipedia.org/wiki/Word_joiner)予伊莫換逝，按呢會當避免 POJ 佮 KIP 的部份出現無合理的佇輕聲符號中央換逝的現象，勞煩恁確認--一下，勞力。

<img width="917" alt="截圖 2024-09-10 下午3 30 23" src="https://github.com/user-attachments/assets/05b9e89e-8f18-44bb-8fcb-6327e99c7c29">

